### PR TITLE
Reducing amount of dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,5 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+/target

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-s3</artifactId>
             <version>${amazonaws.version}</version>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Limiting AWS dependencies to only what is needed limits the dependency footprint.