### PR TITLE
Bucket region name correction for for us-east-1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+# Maven
+target/

--- a/src/main/java/com/github/platform/team/plugin/AmazonS3Wagon.java
+++ b/src/main/java/com/github/platform/team/plugin/AmazonS3Wagon.java
@@ -147,12 +147,13 @@ public final class AmazonS3Wagon extends AbstractWagon {
     }
 
     private static String getBucketRegion(AWSCredentialsProvider credentialsProvider, ClientConfiguration clientConfiguration, String bucketName) {
-        return AmazonS3Client.builder()
+        String bucketRegion = AmazonS3Client.builder()
                 .withCredentials(credentialsProvider)
                 .withClientConfiguration(clientConfiguration)
                 .enableForceGlobalBucketAccess()
                 .build()
                 .getBucketLocation(bucketName);
+        return "US".equals(bucketRegion) ? "us-east-1" : bucketRegion;
     }
 
     @Override


### PR DESCRIPTION
First of all, thank you very much for creating this fork and updating it! It really moved my work forward.

It so happened that I have a bucket in us-east-1. For legacy reasons, AWS SDK's method getBucketLocation does not return us-east-1 when asking about bucket in that region, but the string US instead. That behaviour is [confirmed by AWS employee](https://forums.aws.amazon.com/thread.jspa?messageID=796829&tstart=0) and reflected in the [latest source code](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/transform/Unmarshallers.java#L145). So, for consistency, I propose the following change to address this issue.

I also took liberty to add target/ folder to .gitignore since the project is built with Maven.